### PR TITLE
Corrections to zero-finding, defaults, and comments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/build
 **/dist
 **/*.egg-info
+**/.venv

--- a/py_ballisticcalc/conditions.py
+++ b/py_ballisticcalc/conditions.py
@@ -146,7 +146,6 @@ class Shot(TypedUnits):
     Stores shot parameters for the trajectory calculation
     
     :param max_range: Downrange distance to stop computing trajectory
-    :param step: Distance between each TrajectoryData row to record
     :param zero_angle: The angle between the barrel and horizontal when zeroed
     :param relative_angle: Elevation adjustment added to zero_angle for a particular shot
     :param cant_angle: Rotation of gun around barrel axis, relative to position when zeroed.
@@ -161,14 +160,10 @@ class Shot(TypedUnits):
     winds: list[Wind] = field(default=None)
 
     def __post_init__(self):
-
         if not self.relative_angle:
             self.relative_angle = 0
         if not self.cant_angle:
             self.cant_angle = 0
-        if not self.zero_angle:
-            self.zero_angle = 0
-
         if not self.atmo:
             self.atmo = Atmo.icao()
         if not self.winds:

--- a/py_ballisticcalc/interface.py
+++ b/py_ballisticcalc/interface.py
@@ -43,11 +43,11 @@ class Calculator:
 
     def fire(self, shot: Shot, trajectory_step: [float, Distance],
              extra_data: bool = False) -> HitResult:
-        """Calculates trajectory with current conditions
+        """Calculates trajectory
         :param shot: shot parameters
         :param trajectory_step: step between trajectory points
-        :param filter_flags: filter trajectory points
-        :return: trajectory table
+        :param extra_data: True => store TrajectoryData for every step;
+            False => store TrajectoryData only for each trajectory_step
         """
         step = Settings.Units.distance(trajectory_step)
         self._calc = TrajectoryCalc(self.ammo)
@@ -57,21 +57,16 @@ class Calculator:
         return HitResult(data, extra_data)
 
     # @staticmethod
-    # def danger_space(trajectory: TrajectoryData, target_height: [float, Distance]) -> Distance:
-    #     """Given a TrajectoryData row, we have the angle of travel
-    #     of bullet at that point in its trajectory, which is at distance *d*.
-    #     "Danger Space" is defined for *d* and for a target of height
-    #     `targetHeight` as the error range for the target, meaning
-    #     if the trajectory hits the center of the target when
-    #     the target is exactly at *d*, then "Danger Space" is the distance
-    #     before or after *d* across which the bullet would still hit somewhere on the target.
+    # def danger_space(trajectory: HitResult, target_height: [float, Distance]):
+    #     """For a given target height, danger-space is the change in distance
+    #     to target across which a shot that hits center at the indicated distance
+    #     would still hit somewhere on the target.
     #     (This ignores windage; vertical only.)
-    #
-    #     :param trajectory: single point from trajectory table
-    #     :param target_height: error range for the target
-    #     :return: danger space for target_height specified
+    
+    #     :param trajectory: TrajectoryData
+    #     :param target_height: 
     #     """
-    #
+    
     #     target_height = (target_height if is_unit(target_height)
     #                      else Set.Units.target_height(target_height)) >> Distance.Yard
     #     traj_angle_tan = math.tan(trajectory.angle >> Angular.Radian)

--- a/py_ballisticcalc/interface.py
+++ b/py_ballisticcalc/interface.py
@@ -57,7 +57,7 @@ class Calculator:
         return HitResult(data, extra_data)
 
     # @staticmethod
-    # def danger_space(trajectory: HitResult, target_height: [float, Distance]):
+    # def danger_space(trajectory: HitResult, target_height: [float, Distance], look_angle: [float, Angular]):
     #     """For a given target height, danger-space is the change in distance
     #     to target across which a shot that hits center at the indicated distance
     #     would still hit somewhere on the target.
@@ -65,9 +65,5 @@ class Calculator:
     
     #     :param trajectory: TrajectoryData
     #     :param target_height: 
+    #     :param look_angle:
     #     """
-    
-    #     target_height = (target_height if is_unit(target_height)
-    #                      else Set.Units.target_height(target_height)) >> Distance.Yard
-    #     traj_angle_tan = math.tan(trajectory.angle >> Angular.Radian)
-    #     return Distance.Yard(-(target_height / traj_angle_tan))

--- a/py_ballisticcalc/settings.py
+++ b/py_ballisticcalc/settings.py
@@ -37,8 +37,8 @@ class Settings:  # pylint: disable=too-few-public-methods
         :param value: [float, Distance] maximum calculation step (used internally)
         """
         logging.warning("Settings._MAX_CALC_STEP_SIZE: change this property "
-                        "only if you know what you are doing "
-                        "to big step can corrupt calculation accuracy")
+                        "only if you know what you are doing; "
+                        "too big step can corrupt calculation accuracy")
         if not isinstance(value, (Distance, float, int)):
             raise ValueError("MIN_CALC_STEP_SIZE have to be a type of 'Distance'")
         cls._MAX_CALC_STEP_SIZE = cls.Units.distance(value) >> Distance.Foot

--- a/py_ballisticcalc/trajectory_calc.pyx
+++ b/py_ballisticcalc/trajectory_calc.pyx
@@ -12,7 +12,7 @@ __all__ = ('TrajectoryCalc',)
 cdef double cZeroFindingAccuracy = 0.000005
 cdef double cMinimumVelocity = 50.0
 cdef double cMaximumDrop = -15000
-cdef int cMaxIterations = 10
+cdef int cMaxIterations = 20
 cdef double cGravityConstant = -32.17405
 
 cdef struct CurvePoint:
@@ -187,7 +187,8 @@ cdef class TrajectoryCalc:
 
                 if fabs(range_vector.x - zero_distance) < 0.5 * calc_step:
                     zero_finding_error = fabs(range_vector.y - height_at_zero)
-                    barrel_elevation -= (range_vector.y - height_at_zero) / range_vector.x
+                    if zero_finding_error > cZeroFindingAccuracy:
+                        barrel_elevation -= (range_vector.y - height_at_zero) / range_vector.x
                     break
 
             iterations_count += 1


### PR DESCRIPTION
During preparation and testing of new danger-space logic, found that Shot.zero_angle was setting itself to zero if not assigned, but Calculator.fire() only applies zero elevation if the Shot.zero_angle remains unassigned.